### PR TITLE
Improve hero text and visual effects

### DIFF
--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -43,7 +43,7 @@ export const FinalCTA = () => {
         <div className="max-w-4xl mx-auto text-center">
           <div className="mb-12">
             <h2 className="text-7xl md:text-8xl font-black mb-8 glitch-text tracking-tight">
-              <span className="neon-text">THE</span>
+              <span className="title-text">THE</span>
               <br />
               <span className="text-neon-teal pulse-neon">BIRTH</span>
             </h2>
@@ -56,7 +56,7 @@ export const FinalCTA = () => {
           </div>
 
           <div className="p-8 md:p-12 max-w-2xl mx-auto">
-            <h3 className="text-4xl font-bold mb-6 text-neon-cyan">
+            <h3 className="text-4xl font-bold mb-6 title-text">
               Experience the Future First
             </h3>
             <p className="text-xl text-foreground/70 mb-8 font-light">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -21,12 +21,12 @@ export const HeroSection = () => {
       {/* Content */}
       <div className="relative z-10 text-center max-w-4xl mx-auto px-6">
         <h1 className="text-6xl md:text-8xl font-bold mb-8 glitch-text">
-          <span className="neon-text pulse-neon">THE FUTURE</span>
+          <span className="title-text pulse-neon">THE FUTURE</span>
           <br />
           <span className="text-neon-magenta neon-magenta-text pulse-magenta">IS NOW</span>
         </h1>
-        
-        <p className="text-2xl md:text-3xl text-neon-cyan neon-glow mb-12 max-w-2xl mx-auto">
+
+        <p className="text-2xl md:text-3xl text-white mb-12 max-w-2xl mx-auto">
           What if AI and humans could collaborate to create masterpieces beyond imagination?
         </p>
         

--- a/src/components/NeonManifest.tsx
+++ b/src/components/NeonManifest.tsx
@@ -11,7 +11,7 @@ export const NeonManifest = () => {
         {words.map((w) => (
           <h2
             key={w}
-            className="text-5xl md:text-7xl font-black neon-text neon-glow relative"
+            className="text-5xl md:text-7xl font-black title-text neon-glow relative"
           >
             {w}
           </h2>

--- a/src/components/StorySection.tsx
+++ b/src/components/StorySection.tsx
@@ -22,11 +22,11 @@ export const StorySection = ({
       className="relative min-h-screen flex items-center justify-center overflow-hidden bg-cover bg-center animate-in fade-in transition duration-700"
       style={{ backgroundImage: `url(${image})` }}
     >
-      <div className="absolute left-1/2 -ml-1 w-2 h-2 bg-neon-cyan rounded-full shadow-neon" />
+      <div className="absolute left-1/2 top-1/2 -ml-1 -mt-1 w-2 h-2 bg-neon-teal rounded-full shadow-neon" />
       <div className="absolute inset-0 bg-black/70 backdrop-blur-md" />
       <div className="relative z-10 max-w-3xl mx-auto px-6 text-center space-y-5">
         <div className="text-neon-magenta font-mono">{year}</div>
-        <h2 className="text-5xl font-bold neon-text neon-glow">{title}</h2>
+        <h2 className="text-5xl font-bold title-text neon-glow">{title}</h2>
 
         <h3 className="text-xl text-neon-magenta">{subtitle}</h3>
         <p className="text-lg text-foreground/80 mb-4">{content}</p>

--- a/src/components/VisualStory.tsx
+++ b/src/components/VisualStory.tsx
@@ -51,7 +51,7 @@ export const VisualStory = () => {
 
   return (
     <section className="relative">
-      <div className="absolute left-1/2 top-0 bottom-0 w-px bg-neon-purple/40 pointer-events-none" />
+      <div className="absolute left-1/2 top-0 bottom-0 w-px bg-neon-teal/40 pointer-events-none" />
       {steps.map((step) => (
         <StorySection key={step.id} {...step} />
       ))}

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,11 @@ All colors MUST be HSL.
     color: hsl(var(--neon-cyan));
     text-shadow: 0 0 10px hsl(var(--neon-cyan) / 0.8);
   }
+
+  .title-text {
+    color: hsl(var(--neon-teal));
+    text-shadow: 0 0 10px hsl(var(--neon-teal) / 0.8);
+  }
   
   .cyber-grid {
     background-image: 
@@ -187,7 +192,21 @@ All colors MUST be HSL.
     }
   }
 
+  @keyframes float {
+    from {
+      transform: translateY(0);
+    }
+    to {
+      transform: translateY(-20px);
+    }
+  }
+
   .particle {
-    @apply absolute rounded-full blur-sm animate-ping opacity-60 bg-neon-purple;
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(2px);
+    opacity: 0.6;
+    background: radial-gradient(circle, hsl(var(--neon-purple)), transparent);
+    animation: ping 3s cubic-bezier(0, 0, 0.2, 1) infinite, float 6s ease-in-out infinite;
   }
 }


### PR DESCRIPTION
## Summary
- tweak hero tagline color and remove glow
- improve particle animation and add title-text style
- update timeline styles
- refine manifest and CTA headings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68869b8d01608329b7d69e0f0b905140