### PR TITLE
Fix timeline glow and add smooth fades

### DIFF
--- a/src/components/StorySection.tsx
+++ b/src/components/StorySection.tsx
@@ -1,3 +1,6 @@
+import { cn } from "@/lib/utils";
+import { useInView } from "@/hooks/use-in-view";
+
 interface StorySectionProps {
   id: string;
   title: string;
@@ -16,10 +19,15 @@ export const StorySection = ({
   image,
   highlightText,
 }: StorySectionProps) => {
+  const { ref, inView } = useInView({ threshold: 0.6 });
   return (
     <section
+      ref={ref}
       id={id}
-      className="relative min-h-screen flex items-center justify-center overflow-hidden bg-cover bg-center animate-in fade-in transition duration-700"
+      className={cn(
+        "relative min-h-screen flex items-center justify-center overflow-hidden bg-cover bg-center transition-opacity duration-1000",
+        inView ? "opacity-100" : "opacity-0"
+      )}
       style={{ backgroundImage: `url(${image})` }}
     >
       <div className="absolute left-1/2 top-1/2 -ml-1 -mt-1 w-2 h-2 bg-neon-teal rounded-full shadow-neon" />

--- a/src/components/VisualStory.tsx
+++ b/src/components/VisualStory.tsx
@@ -71,12 +71,12 @@ export const VisualStory = () => {
     <section className="relative">
       {/* Thick blue glowing timeline with random vectors */}
       <svg
-        className="absolute inset-0 w-full h-full pointer-events-none z-10"
+        className="absolute inset-0 w-full h-full pointer-events-none z-10 overflow-visible"
         preserveAspectRatio="none"
         viewBox="0 0 100 100"
       >
         <defs>
-          <filter id="glow">
+          <filter id="glow" x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox">
             <feGaussianBlur stdDeviation="4" result="coloredBlur" />
             <feMerge>
               <feMergeNode in="coloredBlur" />

--- a/src/hooks/use-in-view.ts
+++ b/src/hooks/use-in-view.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useInView(options: IntersectionObserverInit = {}) {
+  const ref = useRef<HTMLElement | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const target = ref.current;
+    if (!target) return;
+    const observer = new IntersectionObserver(([entry]) => {
+      setInView(entry.isIntersecting);
+    }, options);
+    observer.observe(target);
+    return () => {
+      observer.disconnect();
+    };
+  }, [options]);
+
+  return { ref, inView } as const;
+}


### PR DESCRIPTION
## Summary
- fade story section images smoothly using intersection observer
- keep timeline glow from being clipped

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887379ec6b48329b3f5c31cae85818b